### PR TITLE
Fix chainmsg for Optimism Goerli

### DIFF
--- a/src/WarningHeader.tsx
+++ b/src/WarningHeader.tsx
@@ -19,6 +19,8 @@ const WarningHeader: React.FC = () => {
     chainMsg = "Kovan Testnet";
   } else if (chainId === 11155111) {
     chainMsg = "Sepolia Testnet";
+  } else if (chainId == 420) {
+    chainMsg = "Optimism Goerli"
   }
   return (
     <div className="w-full bg-orange-400 text-white text-center font-bold px-2 py-1">


### PR DESCRIPTION
Explicitly tell end users that they are viewing optimism goerli explorer when `chainID == 420`.