### PR TITLE
Ignore DepositTx's gasUsed when BurntFee Calculation for Block Details

### DIFF
--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -27,6 +27,7 @@ import { blockTxsURL } from "./url";
 import { useBlockData } from "./useErigonHooks";
 import { useETHUSDOracle } from "./usePriceOracle";
 import { useChainInfo } from "./useChainInfo";
+import { BigNumber } from "ethers";
 
 const Block: React.FC = () => {
   const { provider } = useContext(RuntimeContext);
@@ -53,8 +54,9 @@ const Block: React.FC = () => {
       console.info(err);
     }
   }, [block]);
+  const gasUsedWithoutDepositTx = block && block.gasUsed.sub(block.gasUsedDepositTx);
   const burntFees =
-    block?.baseFeePerGas && block.baseFeePerGas.mul(block.gasUsed);
+    block?.baseFeePerGas && block.baseFeePerGas.mul(gasUsedWithoutDepositTx ?? BigNumber.from(0));
   const gasUsedPerc =
     block && block.gasUsed.mul(10000).div(block.gasLimit).toNumber() / 100;
 

--- a/src/BlockReward.tsx
+++ b/src/BlockReward.tsx
@@ -16,7 +16,9 @@ const BlockReward: React.FC<BlockRewardProps> = ({ block }) => {
 
   // totalFees = burntFees(baseFee) + netFeeReward(tip)
   const totalFees = block?.feeReward ?? BigNumber.from(0);
-  const burntFees = (block?.baseFeePerGas && block.baseFeePerGas.mul(block.gasUsed)) ?? BigNumber.from(0);
+  // remove depositTx's gasUsed to calculate burntFees because baseFeePerGas is nonsense for depositTx
+  const gasUsedWithoutDepositTx = block.gasUsed.sub(block.gasUsedDepositTx);
+  const burntFees = (block?.baseFeePerGas && block.baseFeePerGas.mul(gasUsedWithoutDepositTx)) ?? BigNumber.from(0);
   const netFeeReward = totalFees.sub(burntFees);
   const value = eth2USDValue
     ? block.blockReward

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -32,6 +32,7 @@ export interface ExtendedBlock extends Block {
   blockReward: BigNumber;
   unclesReward: BigNumber;
   feeReward: BigNumber;
+  gasUsedDepositTx: BigNumber;
   size: number;
   sha3Uncles: string;
   stateRoot: string;
@@ -67,6 +68,7 @@ export const readBlock = async (
     blockReward: provider.formatter.bigNumber(_rawIssuance.blockReward ?? 0),
     unclesReward: provider.formatter.bigNumber(_rawIssuance.uncleReward ?? 0),
     feeReward: provider.formatter.bigNumber(_rawBlock.totalFees),
+    gasUsedDepositTx: provider.formatter.bigNumber(_rawBlock.gasUsedDepositTx ?? 0),
     size: provider.formatter.number(_rawBlock.block.size),
     sha3Uncles: _rawBlock.block.sha3Uncles,
     stateRoot: _rawBlock.block.stateRoot,


### PR DESCRIPTION
This requires backend fix: https://github.com/testinprod-io/op-erigon/pull/43

This PR fixes incorrect results for block detail page(`/block/{blockNumber}`)'s `Burn Fees` field and `Block Reward` field.

Otterscan miscalculated `burntFee`:
```
burntFeeWrong = block.baseFeePerGas * block.gasUsed
```

This is wrong because for deposit transactions, considering `baseFeePerGas` is nonsense because L2 transaction fee is zero for every deposit transaction.

The correct way for deriving `burntFee` is:
```
burntFeeCorrect = block.baseFeePerGas * (block.gasUsed - gasUsedDepositTx)
```


Block reward is also fixed. Block reward has the following formula:
```
blockReward = base block reward + total fee for every tx - total burnt fee
```

`total fee for every tx` and `total burnt fee` had wrong values, larger then the correct result, although `block reward` is correct. We were miscalculating by using below formula:
```
blockReward = base block reward
                   + (total fee for every tx + burntFeeWrong - burntFeeCorrect)
                   - (total burnt fee + burntFeeWrong - burntFeeCorrect)
```

To elaborate, for example, 
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/29061389/233203348-3f0b61f9-3a0e-4e2e-801e-1636bc8c81d0.png">

Upper screenshot has 
```
0.0000001962421874 ETH (0 + 0.00000019625434565 - 0.00000000001215825)
blockReward ( base block reward + total fee for every tx - total burnt fee )
```


Fixed to make these variables to give correct result, by ignoring deposit transaction's `gasUsed` amount.




