### PR TITLE
Consider L1 Fees for Transaction Fee

### DIFF
--- a/src/transaction/RewardSplit.tsx
+++ b/src/transaction/RewardSplit.tsx
@@ -34,9 +34,10 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
       : BigNumber.from(0)
   );
   const minerReward = paidFees.sub(burntFees);
+  // percent may not add up to full 100% 
   const burntPerc = totalFees.isZero() ? 0 : Math.round(burntFees.mul(10000).div(totalFees).toNumber()) / 100;
   const l1Perc = totalFees.isZero() ? 0 : Math.round(l1Fees.mul(10000).div(totalFees).toNumber()) / 100;
-  const minerPerc = Math.round((100 - burntPerc - l1Perc) * 100) / 100;
+  const minerPerc = totalFees.isZero() ? 0 : Math.round(minerReward.mul(10000).div(totalFees).toNumber()) / 100;
 
   return (
     <div className="inline-block">


### PR DESCRIPTION
This PR fixed wrong `RewardSplit` logic for optimism.

Previously L1 Fee was not considered at all.

Transaction Fee is calculated by below formula:

```
transaction fee = burntFee + minerReward + L1Fee
```

This PR takes care of `L1 fee` and fixes percentage calculation for reward split logic.

Example frontend:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/29061389/233062776-143fe1b2-b880-43c3-ba79-5ba3c3c6dfa1.png">

- orange: burnt fee
- amber: minerReward
- blue: L1 security fee

L1 security field is added. Now the gas fees add up to transaction fees.

Now the percentage may not add up to exact 100%.





