### PR TITLE
Support Ecotone

### DIFF
--- a/docs/optimism.md
+++ b/docs/optimism.md
@@ -6,7 +6,7 @@ There are optimism specific tweaks to satisfy [op-stack specifications](https://
 
 Transaction page now shows l1 cost fee related fields:
 - `L1 Gas Price`
-- `L1 Fee Scalar`
+- `L1 Fee Scalar` (not used after [Ecotone hard fork](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md#ecotone-l1-cost-fee-changes-eip-4844-da))
 - `L1 Gas Used by Txn`
 
 ## [Deposit Transaction](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md)

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -55,18 +55,24 @@ export class SearchController {
           fee = BigNumber.from(0);
           gasPrice = BigNumber.from(0);
         } else {
+          // pre ecotone - did not use l1Fee and manually calculated using spec
           // fee = gasPrice * gas + l1GasUsed * l1GasPrice * l1FeeScalar
-          const l1GasUsed: BigNumber = provider.formatter.bigNumber(_rawReceipt.l1GasUsed ?? 0);
-          const l1GasPrice: BigNumber = provider.formatter.bigNumber(_rawReceipt.l1GasPrice ?? 0);
-          const l1FeeScalar: number = parseFloat(_rawReceipt.l1FeeScalar ?? 0);
-          const numDecimals: number = Math.floor(l1FeeScalar) == l1FeeScalar ? 0 : l1FeeScalar.toString().split(".")[1].length || 0;
-          // l1feeScalar is float, so scale up and down
-          const l1FeeScalarScaleFactor: BigNumber = BigNumber.from(10).pow(numDecimals)
-          const l1FeeScalarScaled: BigNumber = BigNumber.from(l1FeeScalar * l1FeeScalarScaleFactor.toNumber())
+          // const l1GasUsed: BigNumber = provider.formatter.bigNumber(_rawReceipt.l1GasUsed ?? 0);
+          // const l1GasPrice: BigNumber = provider.formatter.bigNumber(_rawReceipt.l1GasPrice ?? 0);
+          // const l1FeeScalar: number = parseFloat(_rawReceipt.l1FeeScalar ?? 0);
+          // const numDecimals: number = Math.floor(l1FeeScalar) == l1FeeScalar ? 0 : l1FeeScalar.toString().split(".")[1].length || 0;
+          // // l1feeScalar is float, so scale up and down
+          // const l1FeeScalarScaleFactor: BigNumber = BigNumber.from(10).pow(numDecimals)
+          // const l1FeeScalarScaled: BigNumber = BigNumber.from(l1FeeScalar * l1FeeScalarScaleFactor.toNumber())
           // legacyTx falls in here
           // when EIP1559, do not have to be recalculated: t.maxPriorityFeePerGas!.add(_block.baseFeePerGas!)
           gasPrice = t.gasPrice!
-          fee = _receipt.gasUsed.mul(gasPrice).add(l1GasUsed.mul(l1GasPrice).mul(l1FeeScalarScaled).div(l1FeeScalarScaleFactor));
+          // fee = _receipt.gasUsed.mul(gasPrice).add(l1GasUsed.mul(l1GasPrice).mul(l1FeeScalarScaled).div(l1FeeScalarScaleFactor));
+          
+          // ecotone - directly use l1Fee field
+          const l1Fee = provider.formatter.bigNumber(_rawReceipt.l1Fee ?? 0);
+          const l2Fee = _receipt.gasUsed.mul(gasPrice);
+          fee = l2Fee.add(l1Fee);
         }
         return {
           blockNumber: t.blockNumber!,

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,8 @@ export type ConfirmedTransactionData = {
   logs: Log[];
   l1GasUsed?: BigNumber | undefined;
   l1GasPrice?: BigNumber | undefined;
-  l1FeeScalar?: number | undefined;
+  l1FeeScalar?: number | null | undefined;
+  l1Fee?: BigNumber | undefined;
 };
 
 // The VOID...


### PR DESCRIPTION
According to Ecotone L1 cost fee changes([Spec](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md#ecotone-l1-cost-fee-changes-eip-4844-da)), `l1FeeScalar` field is not used and no longer included in API's rseponse. 

Previously otterscan frontend manually calculated l1 Fee using pre-ecotone formula: `(rollupDataGas + l1FeeOverhead) * l1BaseFee * l1FeeScalar`. API always returned `l1Fee` which is the result of calculation, so now trust the response and directly this field for pre/post ecotone.

Commented out and not removed original code for tracking purposes.

